### PR TITLE
Use `--no-cache` flag instead of manually removing `/var/cache/apk/*`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,4 @@
 
 FROM alpine:3.19.1
 
-RUN apk add --update conntrack-tools && \
-    rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache conntrack-tools


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR passes the `--no-cache` flag to `apk`, instead of manually removing `/var/cache/apk/*`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
