### PR TITLE
Add privacy notice to pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,8 @@ labels: kind/bug
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **What happened**:
 
 **What you expected to happen**:

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -5,6 +5,8 @@ labels: kind/enhancement
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **What would you like to be added**:
 
 **Why is this needed**:


### PR DESCRIPTION
This PR adds a privacy notice to pr and issue template files to remind users not to include company internal information.

Files modified:
- .github/ISSUE_TEMPLATE/bug_report.md
- .github/ISSUE_TEMPLATE/enhancement_request.md