### PR TITLE
chore: delete dependabot.yaml for renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-# Create PRs for alpine version updates
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: daily


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Remove dependabot.yam as we have migrated to renovate


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
